### PR TITLE
Adaptes Unity null conditional operator issue

### DIFF
--- a/src/src/UI/src/src/Behaviour/Alert.cs
+++ b/src/src/UI/src/src/Behaviour/Alert.cs
@@ -115,7 +115,10 @@ namespace Bayhaksam.Unity.UI.Behaviour
 
 		protected virtual void OnEnable()
 		{
-			this.Animator?.Play(this.AlertOpenAnimationStateNameHash);
+			if (this.Animator != null)
+			{
+				this.Animator.Play(this.AlertOpenAnimationStateNameHash);
+			}
 		}
 		#endregion
 


### PR DESCRIPTION
[Issue '941880'](https://issuetracker.unity3d.com/issues/c-number-6-null-conditional-access-operator-dot-throws-missingcomponentexception-instead-of-recognizing-as-null) on Unity Issue Tracker